### PR TITLE
respondent rep removal update correction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.1.94'
+version '0.1.95'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/ecm/common/model/servicebus/tasks/UpdateDataTask.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/model/servicebus/tasks/UpdateDataTask.java
@@ -231,7 +231,12 @@ public class UpdateDataTask extends DataTaskParent {
     private void addRespondentRepRemovalUpdate(CaseData caseData, RepresentedTypeR representedType) {
 
         if (representedTypeRItemExists(caseData, representedType)) {
-            getExistingRepresentedTypeRItem(caseData, representedType).setValue(new RepresentedTypeR());
+
+            var representedTypeRItem = getExistingRepresentedTypeRItem(caseData, representedType);
+
+            if (representedTypeRItem != null) {
+                caseData.getRepCollection().remove(representedTypeRItem);
+            }
         }
 
     }


### PR DESCRIPTION
Code change is made to correct the respondent rep removal update logic.
Also, the tag version is increased to '0.1.95'.

https://tools.hmcts.net/jira/browse/ECM-24




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
