### PR TITLE
Update log4j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.1.157'
+version '0.1.158'
 
 sourceCompatibility = '11.0'
 
@@ -72,10 +72,12 @@ publishing {
 }
 
 def versions = [
-        reformLogging   : '5.1.6'
+    reformLogging   : '5.1.6'
 ]
 
-ext["rest-assured.version"] = '4.4.0'
+ext {
+    log4JVersion = "2.15.0"
+}
 
 // endregion
 
@@ -93,6 +95,8 @@ dependencies {
     implementation group: 'com.github.sps.junidecode', name: 'junidecode', version: '0.3'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
     // CVE-2020-11987, CVE-2020-11988 (batik-1.13)
     // Can be removed when we upgrade poi-ooxml to 6.0
     // https://bz.apache.org/bugzilla/show_bug.cgi?id=65166

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.1.159'
+version '0.1.160'
 
 sourceCompatibility = '11.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ def versions = [
 ]
 
 ext {
-    log4JVersion = "2.15.0"
+    log4JVersion = '2.15.0'
 }
 
 // endregion


### PR DESCRIPTION
### Change description ###
There is a critical vulnerability in all versions of log4j and log4j2.

https://www.lunasec.io/docs/blog/log4j-zero-day/
https://arstechnica.com/information-technology/2021/12/minecraft-and-other-apps-face-serious-threat-from-new-code-execution-bug/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
