### PR TITLE
ES search end date corrected

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 group 'uk.gov.hmcts.reform'
 
-version '0.1.177'
+version '0.1.179'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/ecm/common/client/CcdClient.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/client/CcdClient.java
@@ -302,7 +302,8 @@ public class CcdClient {
             return buildAndGetElasticSearchRequest(authToken, caseTypeId,
                     getReportRangeDateQuery(from, to, reportType));
         } else {
-            String to = LocalDate.parse(dateToSearchTo).atStartOfDay().format(OLD_DATE_TIME_PATTERN);
+            String to = LocalDate.parse(dateToSearchTo).atStartOfDay()
+                .plusDays(1).minusSeconds(1).format(OLD_DATE_TIME_PATTERN);
             log.info(reportType + " - " + from + " - " + to);
             return buildAndGetElasticSearchRequest(authToken, caseTypeId,
                     getReportRangeDateQuery(from, to, reportType));

--- a/src/test/java/uk/gov/hmcts/ecm/common/client/CcdClientTest.java
+++ b/src/test/java/uk/gov/hmcts/ecm/common/client/CcdClientTest.java
@@ -440,7 +440,7 @@ public class CcdClientTest {
     @Test
     public void retrieveCasesGenericReportElasticSearch() throws IOException {
         String jsonQuery = "{\"size\":10000,\"query\":{\"bool\":{\"filter\":[{\"range\":{\"data.bfActions.value"
-                + ".bfDate\":{\"from\":\"2019-09-23T00:00:00.000\",\"to\":\"2019-09-24T00:00:00.000\","
+                + ".bfDate\":{\"from\":\"2019-09-23T00:00:00.000\",\"to\":\"2019-09-24T23:59:59.000\","
                 + "\"include_lower\":true,\"include_upper\":true,\"boost\":1"
                 + ".0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}}}";
         HttpEntity<String> httpEntity = new HttpEntity<>(jsonQuery, creatBuildHeaders());


### PR DESCRIPTION
The end date for Elastic Search is corrected and now is inclusive of hearings, for example, listed on the last day specified for search.

The change affects search results for Members Day and BF Report and possibly all other reports that involve hearings. 

https://tools.hmcts.net/jira/browse/ECM-629


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
