### PR TITLE
ecm-748 bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.1.188'
+version '0.1.189'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/ecm/common/model/reports/claimsbyhearingvenue/ClaimsByHearingVenueCaseData.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/model/reports/claimsbyhearingvenue/ClaimsByHearingVenueCaseData.java
@@ -18,7 +18,7 @@ public class ClaimsByHearingVenueCaseData {
     @JsonProperty("claimantType")
     private ClaimantType claimantType;
 
-    @JsonProperty("claimantWorkAddressType")
+    @JsonProperty("claimantWorkAddress")
     private ClaimantWorkAddressType claimantWorkAddressType;
 
     @JsonProperty("respondentCollection")


### PR DESCRIPTION
The claimantWorkAddress annotation is restored so that ES reading maps correctly. This annotation used to work before I changed it to claimantWorkAddressType. The claimantWorkAddress annotation is now aligned to the annotation used in the CaseData class for the ClaimantWorkAddressType field.

https://tools.hmcts.net/jira/browse/ECM-748

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
