### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ test {
 }
 
 ext {
-    reformLoggingVersion = '5.1.9'
+    reformLoggingVersion = '6.0.1'
     log4JVersion = '2.17.0'
     lombokVersion = '1.18.22'
     junitJupiterVersion = '5.6.3'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.